### PR TITLE
Fix loadConfig missing oauth enabled property

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,6 +8,7 @@ export function loadConfig(env: SecretsEnv): MCPConfig {
   return {
     ...defaults,
     oauth: {
+      enabled: defaults.oauth.enabled,
       provider: defaults.oauth.provider,
       scopes: [...defaults.oauth.scopes],
       redirectUri: defaults.oauth.redirectUri,

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -8,7 +8,7 @@ export function loadConfig(env: SecretsEnv): MCPConfig {
   return {
     ...defaults,
     oauth: {
-      enabled: defaults.oauth.enabled,
+...defaults.oauth,
       provider: defaults.oauth.provider,
       scopes: [...defaults.oauth.scopes],
       redirectUri: defaults.oauth.redirectUri,


### PR DESCRIPTION
## Summary
- include `enabled` when returning OAuth config

## Testing
- `npm run type-check`
- `npm run cf-typegen`

------
https://chatgpt.com/codex/tasks/task_b_6865f7814764832cb89eed5b0bc885d0