### PR TITLE
feat: implement OAuth 2.0 Dynamic Client Registration (RFC 7591)

### DIFF
--- a/src/auth/oauth-types.ts
+++ b/src/auth/oauth-types.ts
@@ -1,0 +1,40 @@
+/**
+ * OAuth Client Registration Request per RFC 7591
+ */
+export interface ClientRegistrationRequest {
+	// Required
+	client_name: string;
+	
+	// Optional
+	redirect_uris?: string[];
+	grant_types?: string[];
+	response_types?: string[];
+	scope?: string;
+	contacts?: string[];
+	logo_uri?: string;
+	client_uri?: string;
+	policy_uri?: string;
+	tos_uri?: string;
+	jwks_uri?: string;
+	jwks?: any; // JSON Web Key Set
+	software_id?: string;
+	software_version?: string;
+}
+
+/**
+ * OAuth Client Registration Response per RFC 7591
+ */
+export interface ClientRegistrationResponse {
+	client_id: string;
+	client_secret?: string;
+	client_id_issued_at: number;
+	client_secret_expires_at?: number;
+	client_name: string;
+	redirect_uris?: string[];
+	grant_types: string[];
+	response_types: string[];
+	token_endpoint_auth_method: string;
+	scope?: string;
+	application_type?: string;
+	subject_type?: string;
+}

--- a/src/auth/timing-safe.ts
+++ b/src/auth/timing-safe.ts
@@ -1,0 +1,22 @@
+/**
+ * Timing-safe string comparison to prevent timing attacks
+ * 
+ * This function compares two strings in constant time to prevent
+ * attackers from using timing differences to guess secret values.
+ */
+export function timingSafeEqual(a: string, b: string): boolean {
+	if (a.length !== b.length) {
+		// Still need to do a comparison to maintain constant time
+		// Compare with a dummy string of the same length as 'a'
+		b = a;
+	}
+	
+	let result = 0;
+	for (let i = 0; i < a.length; i++) {
+		result |= a.charCodeAt(i) ^ b.charCodeAt(i);
+	}
+	
+	// Return true only if all characters matched (result === 0)
+	// and the lengths were originally equal
+	return result === 0 && a.length === b.length;
+}

--- a/src/auth/validation.ts
+++ b/src/auth/validation.ts
@@ -1,0 +1,150 @@
+/**
+ * Input validation utilities for OAuth endpoints
+ */
+
+/**
+ * Validate a URL string
+ */
+export function isValidUrl(url: string): boolean {
+	try {
+		const parsed = new URL(url);
+		// Allow http/https for development, custom schemes for apps
+		return ['http:', 'https:', 'com.app:', 'app:'].some(scheme => 
+			parsed.protocol === scheme || parsed.protocol.startsWith(scheme.split(':')[0] + '.')
+		);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Validate client_name
+ */
+export function validateClientName(name: string): { valid: boolean; error?: string } {
+	if (!name || typeof name !== 'string') {
+		return { valid: false, error: 'client_name is required and must be a string' };
+	}
+	
+	if (name.length < 3) {
+		return { valid: false, error: 'client_name must be at least 3 characters long' };
+	}
+	
+	if (name.length > 100) {
+		return { valid: false, error: 'client_name must not exceed 100 characters' };
+	}
+	
+	// Check for basic alphanumeric + common punctuation
+	if (!/^[\w\s\-._]+$/.test(name)) {
+		return { valid: false, error: 'client_name contains invalid characters' };
+	}
+	
+	return { valid: true };
+}
+
+/**
+ * Validate redirect URIs
+ */
+export function validateRedirectUris(uris?: string[]): { valid: boolean; error?: string } {
+	if (!uris || uris.length === 0) {
+		// Optional field, can be empty
+		return { valid: true };
+	}
+	
+	if (!Array.isArray(uris)) {
+		return { valid: false, error: 'redirect_uris must be an array' };
+	}
+	
+	if (uris.length > 10) {
+		return { valid: false, error: 'Too many redirect_uris (max 10)' };
+	}
+	
+	for (const uri of uris) {
+		if (typeof uri !== 'string') {
+			return { valid: false, error: 'All redirect_uris must be strings' };
+		}
+		
+		// Special case for out-of-band
+		if (uri === 'urn:ietf:wg:oauth:2.0:oob') {
+			continue;
+		}
+		
+		if (!isValidUrl(uri)) {
+			return { valid: false, error: `Invalid redirect_uri: ${uri}` };
+		}
+	}
+	
+	return { valid: true };
+}
+
+/**
+ * Validate grant types
+ */
+export function validateGrantTypes(types?: string[]): { valid: boolean; error?: string } {
+	const allowedGrantTypes = ['authorization_code', 'refresh_token'];
+	
+	if (!types || types.length === 0) {
+		// Optional, will use defaults
+		return { valid: true };
+	}
+	
+	if (!Array.isArray(types)) {
+		return { valid: false, error: 'grant_types must be an array' };
+	}
+	
+	for (const type of types) {
+		if (!allowedGrantTypes.includes(type)) {
+			return { valid: false, error: `Unsupported grant_type: ${type}` };
+		}
+	}
+	
+	return { valid: true };
+}
+
+/**
+ * Validate response types
+ */
+export function validateResponseTypes(types?: string[]): { valid: boolean; error?: string } {
+	const allowedResponseTypes = ['code'];
+	
+	if (!types || types.length === 0) {
+		// Optional, will use defaults
+		return { valid: true };
+	}
+	
+	if (!Array.isArray(types)) {
+		return { valid: false, error: 'response_types must be an array' };
+	}
+	
+	for (const type of types) {
+		if (!allowedResponseTypes.includes(type)) {
+			return { valid: false, error: `Unsupported response_type: ${type}` };
+		}
+	}
+	
+	return { valid: true };
+}
+
+/**
+ * Validate scopes
+ */
+export function validateScopes(scope?: string): { valid: boolean; error?: string } {
+	const allowedScopes = ['mcp:tools', 'profile', 'openid', 'offline_access'];
+	
+	if (!scope) {
+		// Optional
+		return { valid: true };
+	}
+	
+	if (typeof scope !== 'string') {
+		return { valid: false, error: 'scope must be a string' };
+	}
+	
+	const requestedScopes = scope.split(' ').filter(s => s);
+	for (const s of requestedScopes) {
+		if (!allowedScopes.includes(s)) {
+			return { valid: false, error: `Unsupported scope: ${s}` };
+		}
+	}
+	
+	return { valid: true };
+}

--- a/test-oauth-flow.html
+++ b/test-oauth-flow.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>OAuth Flow Test</title>
+    <style>
+        body { font-family: monospace; padding: 20px; }
+        pre { background: #f0f0f0; padding: 10px; overflow-x: auto; }
+        button { padding: 10px 20px; margin: 10px 0; }
+        .error { color: red; }
+        .success { color: green; }
+    </style>
+</head>
+<body>
+    <h1>OAuth Flow Test</h1>
+    
+    <button onclick="startOAuth()">Start OAuth Flow</button>
+    
+    <div id="status"></div>
+    
+    <h2>Current URL:</h2>
+    <pre id="current-url"></pre>
+    
+    <h2>URL Parameters:</h2>
+    <pre id="params"></pre>
+    
+    <script>
+        // Display current URL and params
+        document.getElementById('current-url').textContent = window.location.href;
+        
+        const params = new URLSearchParams(window.location.search);
+        const paramsObj = {};
+        for (const [key, value] of params) {
+            paramsObj[key] = value;
+        }
+        document.getElementById('params').textContent = JSON.stringify(paramsObj, null, 2);
+        
+        // Check if we have an authorization code
+        const code = params.get('code');
+        const error = params.get('error');
+        const errorDescription = params.get('error_description');
+        
+        const statusDiv = document.getElementById('status');
+        
+        if (error) {
+            statusDiv.innerHTML = `<p class="error">OAuth Error: ${error}</p>`;
+            if (errorDescription) {
+                statusDiv.innerHTML += `<p class="error">Description: ${errorDescription}</p>`;
+            }
+        } else if (code) {
+            statusDiv.innerHTML = `<p class="success">Authorization code received!</p>`;
+            statusDiv.innerHTML += `<p>Code: ${code}</p>`;
+            statusDiv.innerHTML += `<p>State: ${params.get('state') || 'none'}</p>`;
+            
+            // Now exchange the code for tokens
+            exchangeCodeForTokens(code);
+        }
+        
+        // Generate PKCE challenge
+        async function generatePKCE() {
+            const verifier = generateRandomString(128);
+            const encoder = new TextEncoder();
+            const data = encoder.encode(verifier);
+            const digest = await crypto.subtle.digest('SHA-256', data);
+            const base64 = btoa(String.fromCharCode(...new Uint8Array(digest)));
+            const challenge = base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+            return { verifier, challenge };
+        }
+        
+        function generateRandomString(length) {
+            const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~';
+            let result = '';
+            const randomValues = new Uint8Array(length);
+            crypto.getRandomValues(randomValues);
+            for (let i = 0; i < length; i++) {
+                result += chars[randomValues[i] % chars.length];
+            }
+            return result;
+        }
+        
+        async function startOAuth() {
+            const pkce = await generatePKCE();
+            
+            // Store PKCE verifier in session storage
+            sessionStorage.setItem('pkce_verifier', pkce.verifier);
+            
+            const params = new URLSearchParams({
+                client_id: 'mcp-inspector',
+                redirect_uri: window.location.origin + window.location.pathname,
+                response_type: 'code',
+                scope: 'mcp:tools profile openid',
+                state: generateRandomString(16),
+                code_challenge: pkce.challenge,
+                code_challenge_method: 'S256'
+            });
+            
+            // Store state for verification
+            sessionStorage.setItem('oauth_state', params.get('state'));
+            
+            const authUrl = `http://localhost:8788/oauth/authorize?${params}`;
+            console.log('Redirecting to:', authUrl);
+            window.location.href = authUrl;
+        }
+        
+        async function exchangeCodeForTokens(code) {
+            const verifier = sessionStorage.getItem('pkce_verifier');
+            const state = params.get('state');
+            const expectedState = sessionStorage.getItem('oauth_state');
+            
+            if (state !== expectedState) {
+                statusDiv.innerHTML += `<p class="error">State mismatch! Expected: ${expectedState}, Got: ${state}</p>`;
+                return;
+            }
+            
+            statusDiv.innerHTML += '<p>Exchanging code for tokens...</p>';
+            
+            try {
+                const response = await fetch('http://localhost:8788/oauth/token', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: new URLSearchParams({
+                        grant_type: 'authorization_code',
+                        code: code,
+                        redirect_uri: window.location.origin + window.location.pathname,
+                        client_id: 'mcp-inspector',
+                        code_verifier: verifier
+                    })
+                });
+                
+                const responseText = await response.text();
+                console.log('Token response:', response.status, responseText);
+                
+                if (response.ok) {
+                    const tokens = JSON.parse(responseText);
+                    statusDiv.innerHTML += '<p class="success">Tokens received!</p>';
+                    statusDiv.innerHTML += '<pre>' + JSON.stringify(tokens, null, 2) + '</pre>';
+                    
+                    // Clean up
+                    sessionStorage.removeItem('pkce_verifier');
+                    sessionStorage.removeItem('oauth_state');
+                } else {
+                    statusDiv.innerHTML += `<p class="error">Token exchange failed: ${response.status}</p>`;
+                    statusDiv.innerHTML += '<pre>' + responseText + '</pre>';
+                }
+            } catch (error) {
+                statusDiv.innerHTML += `<p class="error">Error: ${error.message}</p>`;
+            }
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implements OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591) to support MCP Inspector and other clients
- Adds `/oauth/register` endpoint that accepts client metadata and returns client credentials
- Fixes issue where dynamically registered clients were not recognized in the OAuth flow

## Changes
- **New `/oauth/register` endpoint**: Accepts POST requests with client metadata, validates required fields, generates secure credentials
- **Enhanced token endpoint**: Now supports `client_secret_basic` authentication via Authorization header
- **Dynamic client storage**: Stores registered clients in KV storage (temporary until D1 database implementation)
- **Updated ClientRegistry**: All methods now check KV storage for dynamically registered clients in addition to static registry
- **Improved redirect URI validation**: Better handling of wildcard patterns like `http://localhost:*/auth/callback`
- **Added test page**: `test-oauth-flow.html` for debugging OAuth flows

## Testing
Tested with MCP Inspector:
1. MCP Inspector successfully registers a new client via `/oauth/register`
2. OAuth flow completes successfully with the dynamically registered client
3. Tokens are issued correctly after Microsoft authentication

## Next Steps
- Implement D1 database persistence for registered clients (currently using KV with 1-year TTL)
- Add token revocation and introspection endpoints
- Implement JWKS endpoint for JWT validation

🤖 Generated with [Claude Code](https://claude.ai/code)